### PR TITLE
Redundant await on return statement

### DIFF
--- a/src/users.js
+++ b/src/users.js
@@ -1,3 +1,3 @@
 export async function getUsers() {
-  return await [{ name: "Javi" }, { name: "Núria" }];
+  return [{ name: "Javi" }, { name: "Núria" }];
 }


### PR DESCRIPTION
I know that is just an example, but await is redundant in this case. :blush: