### PR TITLE
Fix dev server by renaming contentBase config …

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -7,6 +7,6 @@ module.exports = merge(common, {
   devtool: "inline-source-map",
   target: "web",
   devServer: {
-    contentBase: "./dist",
+    static: "./dist",
   },
 });


### PR DESCRIPTION
Changing this config option so devServer will run properly as stated in https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#400-beta0-2020-11-27
